### PR TITLE
Cannot update app if network error when downloading update.

### DIFF
--- a/src/ios/DownloadManager.h
+++ b/src/ios/DownloadManager.h
@@ -50,6 +50,17 @@
 
 - (void)didFinishLoadingAllForManager:(DownloadManager *)downloadManager;
 
+
+/** Informs the delegate that have error when downloading (whether successfully or unsuccessfully).
+ *
+ * @param downloadManager
+ *
+ * The `DownloadManager` that is performing the downloads.
+ *
+ * @see DownloadManager
+ */
+- (void)didErrorLoadingAllForManager:(DownloadManager *)downloadManager;
+
 /** Informs the delegate that a particular download has finished successfully.
  *
  * @param downloadManager

--- a/src/ios/DownloadManager.m
+++ b/src/ios/DownloadManager.m
@@ -69,7 +69,7 @@
 
 - (void)start
 {
-    [self tryDownloading];
+    [self tryDownloading: true];
 }
 
 - (void)cancelAll
@@ -82,7 +82,7 @@
     
     self.cancelAllInProgress = NO;
     
-    [self informDelegateThatDownloadsAreDone];
+    [self informDelegateThatDownloadsAreDone: false];
 }
 
 #pragma mark - DownloadDelegate Methods
@@ -95,7 +95,7 @@
         [self.delegate downloadManager:self downloadDidFinishLoading:download];
     }
 
-    [self tryDownloading];
+    [self tryDownloading: true];
 }
 
 - (void)downloadDidFail:(Download *)download
@@ -106,7 +106,7 @@
         [self.delegate downloadManager:self downloadDidFail:download];
 
     if (!self.cancelAllInProgress) {
-        [self tryDownloading];
+        [self tryDownloading: false];
     }
 }
 
@@ -119,21 +119,27 @@
 
 #pragma mark - Private methods
 
-- (void)informDelegateThatDownloadsAreDone
+- (void)informDelegateThatDownloadsAreDone:(Boolean) isSuccess
 {
-    if ([self.delegate respondsToSelector:@selector(didFinishLoadingAllForManager:)]) {
-        [self.delegate didFinishLoadingAllForManager:self];
+    if(isSuccess){
+        if ([self.delegate respondsToSelector:@selector(didFinishLoadingAllForManager:)]) {
+            [self.delegate didFinishLoadingAllForManager:self];
+        }
+    }else{
+        if ([self.delegate respondsToSelector:@selector(didErrorLoadingAllForManager:)]) {
+            [self.delegate didErrorLoadingAllForManager:self];
+        }
     }
 }
 
-- (void)tryDownloading
+- (void)tryDownloading:(Boolean) isSuccess
 {
     NSInteger totalDownloads = [self.downloads count];
     
     // if we're done, inform the delegate
     
     if (totalDownloads == 0) {
-        [self informDelegateThatDownloadsAreDone];
+        [self informDelegateThatDownloadsAreDone: isSuccess];
         return;
     }
     

--- a/src/ios/IonicDeploy.m
+++ b/src/ios/IonicDeploy.m
@@ -464,6 +464,14 @@ typedef struct JsonHttpResponse {
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
 }
 
+- (void)didErrorLoadingAllForManager:(DownloadManager *)downloadManager{
+    NSLog(@"Download Error");
+    CDVPluginResult* pluginResult = nil;
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"download error"];
+    
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+}
+
 - (void)didFinishLoadingAllForManager:(DownloadManager *)downloadManager
 {
     // Save the upstream_uuid (what we just downloaded) to the uuid preference


### PR DESCRIPTION
In iOS, when downloading error because of some network reasons, but plugin dispatch download successful event.
Because of that, app stuck on update screen, if we restart app the app also stuck on splash screen