### PR TITLE
Fix deploy when no compatible versions

### DIFF
--- a/src/ios/IonicDeploy.m
+++ b/src/ios/IonicDeploy.m
@@ -153,7 +153,7 @@ typedef struct JsonHttpResponse {
                 }
             }
 
-            if (update_available == [NSNumber numberWithBool:YES]) {
+            if (update_available == [NSNumber numberWithBool:YES] && compatible == [NSNumber numberWithBool:YES]) {
                 NSLog(@"update is true");
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"true"];
             } else {


### PR DESCRIPTION
This pull request fixes Issue #58 (https://github.com/driftyco/ionic-plugin-deploy/issues/58). This now aligns with Android's implementation (https://github.com/driftyco/ionic-plugin-deploy/blob/574f4bb1bd293d66410bd80c06c6c33e0f5cd19f/src/android/IonicDeploy.java#L331).