### PR TITLE
Add support for cordova-plugin-wkwebview-engine

### DIFF
--- a/src/ios/IonicDeploy.m
+++ b/src/ios/IonicDeploy.m
@@ -3,6 +3,7 @@
 #import "UNIRest.h"
 #import "SSZipArchive.h"
 #import "IonicConstant.h"
+#import <objc/message.h>
 
 @interface IonicDeploy()
 
@@ -358,7 +359,16 @@ typedef struct JsonHttpResponse {
             self.currentUUID = uuid;
 
             NSLog(@"Redirecting to: %@", components.URL.absoluteString);
-             [((UIWebView*)self.webView) loadRequest: [NSURLRequest requestWithURL:components.URL] ];
+            
+            SEL wkWebViewSelector = NSSelectorFromString(@"loadFileURL:allowingReadAccessToURL:");
+            
+            if ([self.webView respondsToSelector:wkWebViewSelector]) {
+                NSURL *readAccessUrl = [components.URL URLByDeletingLastPathComponent];
+                ((id (*)(id, SEL, id, id))objc_msgSend)(self.webView, wkWebViewSelector, components.URL, readAccessUrl);
+            }
+            else {
+                [((UIWebView*)self.webView) loadRequest: [NSURLRequest requestWithURL:components.URL] ];
+            }
         }
         });
     }


### PR DESCRIPTION
This keeps the app from getting stuck on the splash screen when using the cordova-plugin-wkwebview-engine plugin + Ionic deploy.

This is working for me on iOS 8 + 9 with and without the wkwebview plugin installed.