### PR TITLE
document the Cordova plugin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The Cordova plugin for Ionic Deploy.
 
 Check out our [docs](http://docs.ionic.io/docs/deploy-overview) for more detailed information.
 
+
 ## Installation
 
 Using the latest [Ionic CLI](https://github.com/driftyco/ionic-cli):
@@ -20,3 +21,81 @@ $ ionic io init
 # now you can install the plugin
 $ ionic plugin add ionic-plugin-deploy
 ```
+
+
+## Cordova Plugin API
+
+
+### `IonicDeploy`
+
+- this Cordova plugin defines a new global `IonicDeploy` object
+
+- this object exposes the following methods
+
+
+#### `init (appId: String, serverUrl: String)`
+
+- appId: `String`
+- serverUrl: `String`
+
+Example:
+
+```js
+IonicDeploy.init('org.cordova.helloworld', 'https://helloworld.org/deploy')
+```
+
+
+#### `check (appId, channelTag, onSuccess, onError)`
+
+- appId: `String`
+- channelTag: `String`
+- onSuccess: `CheckHandler`
+- onError: `ErrorHandler`
+
+Contact the remote IonicDeploy service (as configured during `IonicDeploy.init(...)`) and determine whether an update is available. Store metadata from available updates for future calls to `IonicDeploy.download(...)`.
+
+
+##### `CheckHandler (result)`
+
+- result: `String`
+
+- if `result` is the string `"true"`, then a new update is available
+
+
+##### `ErrorHandler (error)`
+
+
+#### `download (appId, onSuccess, onError)`
+
+- appId: `String`
+- onSuccess: `ProgressHandler`
+- onError: `ErrorHandler`
+
+Using the metadata from a recent `IonicDeploy.check(...)`, download and store an available update ZIP file.  
+
+
+##### `ProgressHandler (result)`
+
+- result: `String` or `Number`
+
+If `result` is a numeric value, it communicates progress. If `result` is the string `"true"`, it communicates completion.
+
+
+#### `extract (appId, onSuccess, onError)`
+
+- appId: `String`
+- onSuccess: `ProgressHandler`
+- onError: `ErrorHandler`
+
+Unpack and apply the update ZIP file from a recent `IonicDeploy.download(...)`. After the app is [terminated](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/TheAppLifeCycle/TheAppLifeCycle.html#//apple_ref/doc/uid/TP40007072-CH2-SW7) / [destroyed](https://developer.android.com/reference/android/app/Activity.html#onDestroy()) by the operating system, the update will take effect.  
+
+The contents of the ZIP file should be the contents of the platform-specific "www" directory from a Cordova project. This directory is regenerated during `cordova build`.
+
+
+#### `redirect (appId)`
+
+- appId: `String`
+
+Navigate the webview to the version provided by a recent `IonicDeploy.extract(...)`. This is useful for use cases where it is undesirable to wait for the operating system to terminate / destroy the app.
+
+Any unsaved user data / state will be lost, so design your UX and/or data persistence approach accordingly.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Cordova plugin for Ionic Deploy.
 
-Check out our [docs](http://docs.ionic.io/docs/io-introduction) for more detailed information.
+Check out our [docs](http://docs.ionic.io/docs/deploy-overview) for more detailed information.
 
 ## Installation
 


### PR DESCRIPTION
- update link to Ionic Deploy documentation

    - note that the URL in repository description is still a 404

- add documentation for the Cordova plugin API (not everything just a start)

I do plan on documenting the rest of the Cordova plugin API surface as I gain experience with it. I figured I'd see if this PR was the sort of thing you would accept before spending more time.

I'm interested in use cases where Ionic Deploy is used for apps that are not using the Ionic and/or Angular frameworks (e.g. React, Ember, etc).