### PR TITLE
new `parseUpdate()` method for custom remote

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.m]
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Contact the remote IonicDeploy service (as configured during `IonicDeploy.init(.
 #### `download (appId, onSuccess, onError)`
 
 - appId: `String`
-- onSuccess: `ProgressHandler`
+- onSuccess: `DownloadHandler`
 - onError: `ErrorHandler`
 
 Using the metadata from a recent `IonicDeploy.check(...)`, download and store an available update ZIP file.  
 
 
-##### `ProgressHandler (result)`
+##### `DownloadHandler (result)`
 
 - result: `String` or `Number`
 
@@ -84,12 +84,19 @@ If `result` is a numeric value, it communicates progress. If `result` is the str
 #### `extract (appId, onSuccess, onError)`
 
 - appId: `String`
-- onSuccess: `ProgressHandler`
+- onSuccess: `ExtractHandler`
 - onError: `ErrorHandler`
 
 Unpack and apply the update ZIP file from a recent `IonicDeploy.download(...)`. After the app is [terminated](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/TheAppLifeCycle/TheAppLifeCycle.html#//apple_ref/doc/uid/TP40007072-CH2-SW7) / [destroyed](https://developer.android.com/reference/android/app/Activity.html#onDestroy()) by the operating system, the update will take effect.  
 
 The contents of the ZIP file should be the contents of the platform-specific "www" directory from a Cordova project. This directory is regenerated during `cordova build`.
+
+
+##### `ExtractHandler (result)`
+
+- result: `String` or `Number`
+
+If `result` is a numeric value, it communicates progress. If `result` is the string `"done"`, it communicates completion.
 
 
 #### `redirect (appId)`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ IonicDeploy.init('org.cordova.helloworld', 'https://helloworld.org/deploy')
 - onSuccess: `CheckHandler`
 - onError: `ErrorHandler`
 
-Contact the remote IonicDeploy service (as configured during `IonicDeploy.init(...)`) and determine whether an update is available. Store metadata from available updates for future calls to `IonicDeploy.download(...)`.
+Contact the remote IonicDeploy service (as configured during `IonicDeploy.init(...)`) and passes the result along to `IonicDeploy.init(...)`.
 
 
 ##### `CheckHandler (result)`
@@ -65,13 +65,39 @@ Contact the remote IonicDeploy service (as configured during `IonicDeploy.init(.
 ##### `ErrorHandler (error)`
 
 
+#### `parseUpdate (appId, response, onSuccess, onError)`
+
+- appId: `String`
+- response: `UpdateResponse`
+- onSuccess: `CheckHandler`
+- onError: `ErrorHandler`
+
+Determine whether an update is available, by checking the provided response data. Store metadata from available updates for future calls to `IonicDeploy.download(...)`.
+
+This function is useful for testing, and also for using a custom remote update service. For all other use cases, you should just use `IonicDeploy.check(...)`.
+
+
+##### `UpdateResponse`
+
+```
+interface UpdateResponse {
+  data: {
+    available: Boolean,
+    compatible: Boolean,
+    snapshot: String, // (unique per update, e.g. UUID)
+    url: String // (URL to download)
+  }
+}
+```
+
+
 #### `download (appId, onSuccess, onError)`
 
 - appId: `String`
 - onSuccess: `DownloadHandler`
 - onError: `ErrorHandler`
 
-Using the metadata from a recent `IonicDeploy.check(...)`, download and store an available update ZIP file.  
+Using the metadata from a recent `IonicDeploy.check(...)` (or `IonicDeploy.parseUpdate(...)`), download and store an available update ZIP file.
 
 
 ##### `DownloadHandler (result)`
@@ -87,7 +113,7 @@ If `result` is a numeric value, it communicates progress. If `result` is the str
 - onSuccess: `ExtractHandler`
 - onError: `ErrorHandler`
 
-Unpack and apply the update ZIP file from a recent `IonicDeploy.download(...)`. After the app is [terminated](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/TheAppLifeCycle/TheAppLifeCycle.html#//apple_ref/doc/uid/TP40007072-CH2-SW7) / [destroyed](https://developer.android.com/reference/android/app/Activity.html#onDestroy()) by the operating system, the update will take effect.  
+Unpack and apply the update ZIP file from a recent `IonicDeploy.download(...)`. After the app is [terminated](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/TheAppLifeCycle/TheAppLifeCycle.html#//apple_ref/doc/uid/TP40007072-CH2-SW7) / [destroyed](https://developer.android.com/reference/android/app/Activity.html#onDestroy()) by the operating system, the update will take effect.
 
 The contents of the ZIP file should be the contents of the platform-specific "www" directory from a Cordova project. This directory is regenerated during `cordova build`.
 

--- a/src/ios/IonicDeploy.h
+++ b/src/ios/IonicDeploy.h
@@ -22,6 +22,8 @@
 
 - (void) check:(CDVInvokedUrlCommand *)command;
 
+- (void) parseUpdate:(CDVInvokedUrlCommand *)command;
+
 - (void) download:(CDVInvokedUrlCommand *)command;
 
 - (void) extract:(CDVInvokedUrlCommand *)command;

--- a/www/ionicdeploy.js
+++ b/www/ionicdeploy.js
@@ -79,7 +79,19 @@ var IonicDeploy = {
       'getMetadata',
       [app_id, uuid]
     );
-  }
+  },
+  parseUpdate: function(app_id, jsonResponse, success, failure) {
+    if (typeof jsonReponse !== 'string') {
+      jsonResponse = JSON.stringify(jsonResponse);
+    }
+    cordova.exec(
+      success,
+      failure,
+      'IonicDeploy',
+      'parseUpdate',
+      [app_id, jsonResponse]
+    );
+  },
 }
 
 module.exports = IonicDeploy;


### PR DESCRIPTION
- expose new `parseUpdate()` to JavaScript

    - this is intended to be used when the built-in network behaviour of `check()` is inappropriate

    - this is mostly just extracted from the `check()` method, which now calls this new `parseUpdate()` so there's no duplication of effort / code

- allows new avenues for testing, and also for customising the remote update service

- also, add an [EditorConfig](http://editorconfig.org/) file for IDE happiness

- sample based on fresh Cordova project: https://gist.github.com/jokeyrhyme/eadfdcd2959a1c988d6ea18e8faf5f33

## Work In Progress

- [x] README.md updated with new APIs
- [x] Android implementation
- [x] Android thoroughly tested (traditional `check()`)
- [x] Android thoroughly tested (new alternative `parseUpdate()`)
- [x] iOS implementation
- [x] iOS thoroughly tested (traditional `check()`) (thanks, @maggieshi !)
- [x] iOS thoroughly tested (new alternative `parseUpdate()`)
- [x] finalise the name for the new function (the hardest part)
