### PR TITLE
[#79] reload the web view after a new version is applied

### DIFF
--- a/src/ios/IonicDeploy.m
+++ b/src/ios/IonicDeploy.m
@@ -404,9 +404,20 @@ static NSOperationQueue *delegateQueue;
             if ([self.webView respondsToSelector:wkWebViewSelector]) {
                 NSURL *readAccessUrl = [components.URL URLByDeletingLastPathComponent];
                 ((id (*)(id, SEL, id, id))objc_msgSend)(self.webView, wkWebViewSelector, components.URL, readAccessUrl);
+
+                dispatch_async(dispatch_get_main_queue(), ^(void){
+                    NSLog(@"Reloading the WKWebView.");
+                    SEL wkWebViewReloadSelector = NSSelectorFromString(@"reload");
+                    ((id (*)(id, SEL))objc_msgSend)(self.webView, wkWebViewReloadSelector);
+                });
             }
             else {
                 [((UIWebView*)self.webView) loadRequest: [NSURLRequest requestWithURL:components.URL] ];
+
+                dispatch_async(dispatch_get_main_queue(), ^(void){
+                    NSLog(@"Reloading the UIWebView.");
+                    [((UIWebView*)self.webView) reload];
+                });
             }
         }
         });


### PR DESCRIPTION
Hello. I am facing an issue that might be connected to [#79]. Looks like after applying the update plugins are not reinstantiated. The problem might be that you are not loading new assets for the WebView in a main thread only in an async queue.

Some time ago a did a similar mechanism from scratch [link](http://blog.ragnarson.com/2016/02/23/cordova-instant-code-updates.html) . After copying the new assets I called a `reload` method on a `UIWebView` instance. 

After the following changes looks like the problem is gone and plugins are hooked up correctly.

If the change makes sense for you then it would be great if you could do the same for Android. We are trying to use Ionic Deploy in production for our app and this is kind of a blocker.

take care
